### PR TITLE
Add contact email

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,8 +109,11 @@
           <a href="https://github.com/opentffoundation/manifesto">creating a
           PR</a> and adding yourself at the bottom of this page and optionally
           let us know how you’d like to help, either as an individual or as an
-          organization.
+          organization. If you have questions or are a member of the press,
+          you may contact us at <a href="mailto:pledge@opentf.org">pledge@opentf.org</a>.
         </p>
+
+        <h2>Press Contact
 
         <h2>Pledges</h2>
 


### PR DESCRIPTION
Adds the pledge@opentf.org email to the manifesto to make it easier to contact us to ask questions.