### PR TITLE
Reorder sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,18 @@
           organization.
         </p>
         
+        <h2>Pledges</h2>
+
+        <ul>
+          <li><a href="https://digger.dev">Digger</a> - Development; Open-source community efforts</li>
+          <li><a href="https://env0.com">env0</a> - Cover the cost of 5 FTEs for at least 5 years</li>
+          <li><a href="https://gruntwork.io">Gruntwork</a> - Development; Open-source community efforts</li>
+          <li><a href="https://massdriver.cloud">Massdriver</a> - Development; Open-source community efforts</li>
+          <li><a href="https://scalr.com">Scalr</a> - Cover the cost of 3 FTEs for at least 5 years</li>
+          <li><a href="https://spacelift.io">Spacelift</a> - Cover the cost of 5 FTEs for at least 5 years</li>
+          <li><a href="https://terrateam.io">Terrateam</a> - Development; Open-source community efforts</li>
+        </ul>
+     
         <h2>Contact us</h2>
 
         <p>
@@ -142,7 +154,7 @@
           <a href="mailto:pledge@opentf.org">pledge@opentf.org</a>.
         </p>
 
-        <h2>Pledges</h2>
+        <h2>Share</h2>
 
         <!-- Sharingbutton Twitter -->
         <a class="resp-sharing-button__link"
@@ -172,20 +184,9 @@
           </div>
         </a>
 
-        <ul>
-          <li><a href="https://digger.dev">Digger</a> - Development; Open-source community efforts</li>
-          <li><a href="https://env0.com">env0</a> - Cover the cost of 5 FTEs for at least 5 years</li>
-          <li><a href="https://gruntwork.io">Gruntwork</a> - Development; Open-source community efforts</li>
-          <li><a href="https://massdriver.cloud">Massdriver</a> - Development; Open-source community efforts</li>
-          <li><a href="https://scalr.com">Scalr</a> - Cover the cost of 3 FTEs for at least 5 years</li>
-          <li><a href="https://spacelift.io">Spacelift</a> - Cover the cost of 5 FTEs for at least 5 years</li>
-          <li><a href="https://terrateam.io">Terrateam</a> - Development; Open-source community efforts</li>
-        </ul>
-     
-
         <p>
           August 14th, 2023
-        </p>
+        </p>        
       </div>
     </div>
   </body>


### PR DESCRIPTION
I found it weird that the "contact us" and "sharing" stuff was within the "List of pledging companies" section... I moved both of those below the section instead. Here's what it looks like now:

![Screen Shot 2023-08-14 at 7 46 21 PM](https://github.com/opentffoundation/manifesto/assets/711908/7a180504-b8f8-468b-b23b-8ba89065be2c)
