### PR TITLE
Adds 35up GmbH to OpenTF manifesto

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,11 @@
           </thead>
           <tbody>
             <tr>
+              <td><a href="https://35up.com">35up</a></td>
+              <td>Company</td>
+              <td>Testing; code reviews; open-source community efforts</td>
+            </tr>
+            <tr>
               <td><a href="https://gruntwork.io">Gruntwork</a></td>
               <td>Company</td>
               <td>Development; open-source community efforts</td>


### PR DESCRIPTION
We are heavy users of Terraform and despite not being affected by the recent license change (in theory at least), we prefer to use Open Source software as much as possible and to contribute back to the community. The new license adopted in the recent surprising move by Hashicorp will definitely demotivate these actions.

We are happy to support with testing, code reviews and all sorts of open source community efforts within our capabilities.

Also, we'll always look forward to contribute with effective development of the tool, as long as the codebase is kept under the commitment of open source **forever**.