### PR TITLE
add Oxide Computer Company

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,11 @@
               <td>Company</td>
               <td>Development; open-source community efforts</td>
             </tr>            
+            <tr>
+              <td><a href="https://oxide.computer">Oxide Computer Company</a></td>
+              <td>Company</td>
+              <td>Development; open-source community efforts</td>
+            </tr>            
           </tbody>
         </table>
 


### PR DESCRIPTION
Our statement (for attribution):

At Oxide, our vision has been that on-premises infrastructure is deserving of a system consisting of both hardware and software, at once integrated and open.  Ensuring Terraform users can easily deploy to Oxide has been essential for realizing this vision: we want customers of an Oxide rack to be able to use the tools that they know and love!  And while HashiCorp's move to the BSL does not immediately affect Oxide (our Terraform provider is and remains MPLv2), we recognize that the ambiguity in both the license and HashCorp's language has created widespread concern that gives customers pause. We support the OpenTF efforts to assure an open source Terraform.  It is our preference to see an MPLv2 Terraform as led by HashiCorp, and we join the call from the OpenTF signatories for HashiCorp to renew its social contract with the community by reverting the change of Terraform to the BSL.  That said, we also agree with OpenTF's fallback position:  a BSL-licensed Terraform is not in fact tenable; if Terraform must be forked into a foundation to assure its future, we will support these efforts.  Open source comprises the foundation of the modern Internet, and is bigger than one company:  it is the power of us all together to determine our fate.  But we cannot take that foundation for granted -- and we must be willing to work to exercise that power to assure an open source future.