### PR TITLE
Adding devbyaccident to opentf manifesto

### DIFF
--- a/index.html
+++ b/index.html
@@ -2209,6 +2209,11 @@
               <td>Individual</td>
               <td>DevOps; IaC; Terraform;  open-source community efforts</td>
             </tr>
+            <tr>
+              <td><a href="https://github.com/devbyaccident">Chris Blackden</a></td>
+              <td>Individual</td>
+              <td>DevOps; Documentation; Training; open-source community efforts</td>
+            </tr>
           </tbody>
         </table>
         <p>


### PR DESCRIPTION
I've been teaching Terraform as an open-source tool online on pluralsight and in-person for the better part of 3 years, as well as writing how-to articles and using it in production. Would like to see it remain open-source, or switch to a fork that is.