### PR TITLE
chore: language and whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <html>
-  
+
   <head>
     <title>OpenTF Foundation</title>
 
@@ -7,16 +7,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="robots" content="index" />
 
-    <meta name="description"
-      content="The OpenTF Foundation. Supporting an impartial, open, and community-driven Terraform." />
+    <meta name="description" content="The OpenTF Foundation. Supporting an impartial, open, and community-driven Terraform." />
 
     <link rel="canonical" href="/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&display=swap" />
     <link rel="stylesheet" type="text/css" href="style.css">
 
     <script async defer src="https://buttons.github.io/buttons.js"></script>
@@ -28,7 +24,7 @@
 
       <div>
         <p>
-          Terraform was open-sourced in 2014 under the Mozilla Public License (v 2.0) (the “MPL”).
+          Terraform was open-sourced in 2014 under the Mozilla Public License (v2.0) (the “MPL”).
           Over the next ~9 years, it built up a community that included thousands of users, contributors, customers,
           certified practitioners, vendors, and an ecosystem of open-source modules, plugins,
           libraries, and extensions.
@@ -46,14 +42,14 @@
 
         <p>
           Overnight, tens of thousands of businesses, ranging from one-person shops to the
-          Fortune 500, woke up to a new reality where the underpinnings of their infrastructure
+          Fortune 500 woke up to a new reality where the underpinnings of their infrastructure
           suddenly became a potential legal risk. The BUSL and the additional use grant written by
           the HashiCorp team are vague, and now every company, vendor, and developer using Terraform
           has to wonder whether what they are doing could be construed as competitive with HashiCorp's
           offerings. The FAQ provides some solace for end-customers and systems integrators today,
           but even if you might be in the clear now, how can you build confidence that your usage
           won't violate the license terms in the future? What if your products or HashiCorp's products
-          change? What if HashiCorp changes how they interpret competitive? What if they change the
+          change? What if HashiCorp changes how they interpret “competitive”? What if they change the
           license again? As a result, everything that uses Terraform is on shaky ground.
         </p>
 
@@ -85,8 +81,8 @@
         </p>
 
         <p>
-          Our aim with this manifesto is to return Terraform to a fully open source license. BSL
-          is <em>not</em> open source, so this would mean moving Terraform back to the MPL license,
+          Our aim with this manifesto is to return Terraform to a fully open source license. BUSL
+          is <em>not</em> open source, so this would mean moving Terraform back to the MPL license
           or some other well-known, widely accepted open source license (e.g., Apache License 2.0).
           Moreover, we want to be confident that Terraform will always remain open source, so you
           don't have to worry about another sudden license change putting everything at risk.
@@ -98,7 +94,7 @@
 
         <p>
           We ask HashiCorp to do the right thing by the community: instead of going forward with the
-          BUSL license change, switch Terraform back to a truly open source license, and commit to keeping
+          BUSL license change, switch Terraform back to a truly open source license and commit to keeping
           it that way forever going forward. That way, instead of fracturing the community, we end up with
           a single, impartial, reliable home for Terraform where the whole community can unite to keep
           building this amazing ecosystem.
@@ -113,7 +109,7 @@
           the legacy MPL-licensed Terraform and maintain the fork in the foundation. This is similar to how
           Linux and Kubernetes are managed by foundations (the Linux Foundation and the Cloud Native
           Computing Foundation, respectively), which are run by multiple companies, ensuring the tool stays
-          truly open source and neutral, and not at the whim of any one company.
+          truly open source and neutral and not at the whim of any one company.
         </p>
 
         <p>
@@ -123,7 +119,7 @@
         <ul>
           <li>
             <span class="font-bold">Truly open source</span> - under a well-known and widely-accepted license that companies can trust,
-            that won't suddenly change in the future, and isn't subject to the whims of a single vendor
+            that won't suddenly change in the future and isn't subject to the whims of a single vendor
           </li>
           <li>
             <span class="font-bold">Community-driven</span> - so that the community governs the project for the community, where pull
@@ -226,34 +222,34 @@
         </p>
 
         <p class="font-bold" id="regular-user">
-          I'm a regular Terraform user and I'm not competing with HashiCorp. Why should I care? <a href="#regular-user"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M13.5442 10.4558C11.8385 8.75022 9.07316 8.75022 7.36753 10.4558L4.27922 13.5442C2.57359 15.2498 2.57359 18.0152 4.27922 19.7208C5.98485 21.4264 8.75021 21.4264 10.4558 19.7208L12 18.1766" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/> <path d="M10.4558 13.5442C12.1614 15.2498 14.9268 15.2498 16.6324 13.5442L19.7207 10.4558C21.4264 8.75021 21.4264 5.98485 19.7207 4.27922C18.0151 2.57359 15.2497 2.57359 13.5441 4.27922L12 5.82338" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/> </svg></a>
+          I'm a regular Terraform user, and I'm not competing with HashiCorp. Why should I care? <a href="#regular-user"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M13.5442 10.4558C11.8385 8.75022 9.07316 8.75022 7.36753 10.4558L4.27922 13.5442C2.57359 15.2498 2.57359 18.0152 4.27922 19.7208C5.98485 21.4264 8.75021 21.4264 10.4558 19.7208L12 18.1766" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/> <path d="M10.4558 13.5442C12.1614 15.2498 14.9268 15.2498 16.6324 13.5442L19.7207 10.4558C21.4264 8.75021 21.4264 5.98485 19.7207 4.27922C18.0151 2.57359 15.2497 2.57359 13.5441 4.27922L12 5.82338" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/> </svg></a>
         </p>
         <p>
           How do you know you're not competing with HashiCorp? 
         </p>
         <p>
-          That's not meant to be a redundant or snarky question. The key issue with the BSL is that the wording is 
+          That's not meant to be a redundant or snarky question. The key issue with the BUSL is that the wording is 
           intentionally vague. What does "competing" mean? What does "hosting or embedding" mean? Who decides?
         </p>
         <p>
           The answer to all these questions is that, in order to really know if you're a competitor, you 
           have to reach out to HashiCorp. So whether your usage is valid is <em>not</em> controlled by the terms of the
-          license, but is instead entirely at the whim of HashiCorp. They get to decide on a case by case basis who is 
+          license but is instead entirely at the whim of HashiCorp. They get to decide on a case-by-case basis who is 
           and who isn't a competitor—and they can change their mind at any time.
         </p>
         <p>
-          That is very shaky footing on which to build anything.
+          That is a very shaky footing on which to build anything.
         </p>
         <p>
           At every company you ever work at in the future, before starting to use Terraform, the CTO will have to think 
-          about whether HashiCorp could possibly consider you a competitor, now, or at any time in the future. The 
-          legal team at that company will have to wonder if they want to take the risk of allowing a BSL license, or if 
+          about whether HashiCorp could possibly consider you a competitor, now or at any time in the future. The 
+          legal team at that company will have to wonder if they want to take the risk of allowing a BUSL license or if 
           they should ban it due to all the uncertainty. Every developer at that company will have to wonder if they 
           want to contribute back to Terraform, given there's no certainty they'll be able to use their own work at a
           future job. 
         </p>
         <p>
-          In short, the BSL is a poison pill for the entire Terraform community.
+          In short, the BUSL is a poison pill for the entire Terraform community.
         </p>
 
         <p class="font-bold" id="why-fork">
@@ -261,8 +257,8 @@
         </p>
         <p>
           Terraform was under the MPL license for ~9 years. This created an understanding—an implicit contract—that 
-          Terraform is open source and you can use it for just about anything you want. Based on that understanding, 
-          tens of thousands of developers adopted the tool, and contributed back to it. HashiCorp even had all 
+          Terraform is open source, and you can use it for just about anything you want. Based on that understanding, 
+          tens of thousands of developers adopted the tool and contributed back to it. HashiCorp even had all 
           contributors sign a CLA which explicitly said 
           (<a href="https://web.archive.org/web/20230610041432/https://www.hashicorp.com/cla">link to the CLA in the 
           Internet Archive</a> as HashiCorp has of course removed this wording):
@@ -271,18 +267,18 @@
           <blockquote>
           HashiCorp is committed to having a true Free and Open Source Software (“FOSS”) license for our non-commercial 
           software. A CLA enables HashiCorp to safely commercialize our products while keeping a standard FOSS license 
-          with all the rights that license grants to users: the ability to use the project in their own projects or 
-          businesses, to republish modified source, or to completely fork the project.
+          with all the rights that the license grants to users: the ability to use the project in their own projects or 
+          businesses, to republish modified source, or to fork the project completely.
           </blockquote>
         </figure>
         <p>
-          The move to BSL—which is <em>not</em> a free and open source license—broke the implicit contract. <em>That</em>
+          The move to BUSL—which is <em>not</em> a free and open source license—broke the implicit contract. <em>That</em>
           was the brash action!
         </p>
         <p>
-          Terraform would've never gotten the adoption it did, or all the contributions from the community, had it not
-          been open source. Most of us would've never agreed to the CLA to contribute to the project if it was BSL 
-          licensed. Taking all those contributions and all that community trust, and then changing to the BSL license
+          Terraform would've never gotten the adoption it did, or all the contributions from the community had it not
+          been open source. Most of us would've never agreed to the CLA to contribute to the project if it was BUSL 
+          licensed. Taking all those contributions and all that community trust, and then changing to the BUSL license
           is a bait and switch.
         </p>
         <p>
@@ -291,11 +287,11 @@
         </p>
 
         <p class="font-bold" id="contribute-back">
-          Didn't HashiCorp adopt BSL to deter vendors who were using Terraform but not contributing back? <a href="#contribute-back"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M13.5442 10.4558C11.8385 8.75022 9.07316 8.75022 7.36753 10.4558L4.27922 13.5442C2.57359 15.2498 2.57359 18.0152 4.27922 19.7208C5.98485 21.4264 8.75021 21.4264 10.4558 19.7208L12 18.1766" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/> <path d="M10.4558 13.5442C12.1614 15.2498 14.9268 15.2498 16.6324 13.5442L19.7207 10.4558C21.4264 8.75021 21.4264 5.98485 19.7207 4.27922C18.0151 2.57359 15.2497 2.57359 13.5441 4.27922L12 5.82338" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/> </svg></a>
+          Didn't HashiCorp adopt BUSL to deter vendors who were using Terraform but not contributing back? <a href="#contribute-back"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M13.5442 10.4558C11.8385 8.75022 9.07316 8.75022 7.36753 10.4558L4.27922 13.5442C2.57359 15.2498 2.57359 18.0152 4.27922 19.7208C5.98485 21.4264 8.75021 21.4264 10.4558 19.7208L12 18.1766" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/> <path d="M10.4558 13.5442C12.1614 15.2498 14.9268 15.2498 16.6324 13.5442L19.7207 10.4558C21.4264 8.75021 21.4264 5.98485 19.7207 4.27922C18.0151 2.57359 15.2497 2.57359 13.5441 4.27922L12 5.82338" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/> </svg></a>
         </p>
         <p>
           In the <a href="https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license">blog post</a> where 
-          HashiCorp announces the switch to BSL, they justify the license switch as a response to the following:
+          HashiCorp announces the switch to BUSL, and they justify the license switch as a response to the following:
         </p>
         <figure>
           <blockquote>
@@ -305,7 +301,7 @@
           </blockquote>
         </figure>
         <p>
-          This is inaccurate and misleading. First of all, many of the vendors affected by the change to BSL have made
+          This is inaccurate and misleading. First of all, many of the vendors affected by the change to BUSL have made
           considerable contributions to the Terraform community. Here are just a handful of examples:
         </p>
         <ul>
@@ -332,7 +328,7 @@
             and countless others that were <em>not</em> built by HashiCorp employees.
           </li>
           <li>
-            <b>Learning resources</b>: There are thousands of books, blog posts, courses and courses, such as 
+            <b>Learning resources</b>: There are thousands of books, blog posts, courses, and courses, such as 
             <em><a href="https://www.terraformupandrunning.com/">Terraform: Up & Running</a></em>,
             <a href="https://www.terraform-best-practices.com/">Terraform Best Practices</a>,
             <a href="https://www.udemy.com/topic/terraform/">Udemy courses</a>,
@@ -809,12 +805,12 @@
               <td>Development; open-source community; Different IaaS stack deployment</td>
             </tr>
             <tr>
-	            <td><a href="https://redarcs.io">Red Arcs Consulting GmbH</a></td>
+              <td><a href="https://redarcs.io">Red Arcs Consulting GmbH</a></td>
               <td>Company</td>
               <td>Development; open-source community</td>
             </tr>
             <tr>
-	            <td><a href="https://dynamicops.co">DynamicOps Limited</a></td>
+              <td><a href="https://dynamicops.co">DynamicOps Limited</a></td>
               <td>Company</td>
               <td>Cloud Infrastructure; Security; Development</td>
             </tr>
@@ -828,7 +824,7 @@
               <td>Company</td>
               <td>Development; open-source community efforts</td>
             </tr>
-	          <tr>
+            <tr>
               <td><a href="https://cloudcode.ai">Cloud Code AI</a></td>
               <td>Company</td>
               <td>Development; open-source community efforts;</td>
@@ -2007,7 +2003,7 @@
               <td>Individual</td>
               <td>Documentation; Development; Testing</td>
             </tr>
-            <tr>            
+            <tr>
               <td><a href="https://github.com/rhernaus">Ron Hernaus</a></td>
               <td>Individual</td>
               <td>Development; open-source community efforts</td>
@@ -2236,11 +2232,11 @@
               <td><a href="https://github.com/amirkhonov">Akbarkhon Amirkhonov</a></td>
               <td>Individual</td>
               <td>DevOps; IaC; Terraform;  open-source community efforts</td>
-              <tr>
-                <td><a href="https://github.com/resker/">Rob Esker</a></td>
-                <td>Individual</td>
-                <td>Development; Documentation; open-source community efforts</td>
-              </tr>
+            </tr>
+            <tr>
+              <td><a href="https://github.com/resker/">Rob Esker</a></td>
+              <td>Individual</td>
+              <td>Development; Documentation; open-source community efforts</td>
             </tr>
             <tr>
               <td><a href="https://github.com/qjoly">Quentin JOLY</a></td>
@@ -2302,7 +2298,7 @@
               <td>Individual</td>
               <td>Development; open-source community efforts</td>
             </tr>
-	          <tr>
+            <tr>
               <td><a href="https://github.com/kevin-fagan">Kevin Fagan</a></td>
               <td>Individual</td>
               <td>Development; open-source community efforts</td>
@@ -2312,7 +2308,6 @@
               <td>Individual</td>
               <td>Development; open-source community efforts</td>
             </tr>
-
             <tr>
               <td><a href="https://github.com/mahesh00009">Mahesh Dhungel</a></td>
               <td>Individual</td>
@@ -2327,7 +2322,7 @@
               <td><a href="https://github.com/cosmicvibes">Charlie Pearce</a></td>
               <td>Individual</td>
               <td>Administration; open-source community efforts</td>
-            </tr>		
+            </tr>
           </tbody>
         </table>
         </div>
@@ -2337,4 +2332,5 @@
       </div>
     </div>
   </body>
+
 </html>


### PR DESCRIPTION
I know you guys disagree that "open source" as an adjective should use a dash (although I see you already use it in many places, which makes the text inconsistent). I've applied some Grammarly suggestions and used "BUSL" for consistency (you also need to update the project's description, which still uses "BSL").

If you agree in the comments, I can also make "open-source" consistent. 😉 

I fixed some broken HTML, white space, alignment, etc.

Please, appreciate my effort! I care about keeping Terraform genuinely open!