### PR TITLE
fix unclosed td tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -2336,7 +2336,7 @@
             <tr>
               <td><a href="https://github.com/d3vilh">Mr. Philipp</a></td>
               <td>Individual</td>
-              <td>SW Development manager; open-source community efforts/td>
+              <td>SW Development manager; open-source community efforts</td>
             </tr>
             <tr>
               <td><a href="https://github.com/cosmicvibes">Charlie Pearce</a></td>
@@ -2346,7 +2346,7 @@
             <tr>
               <td><a href="https://github.com/alwindoss">Alwin Doss</a></td>
               <td>Individual</td>
-              <td>SW Developer; open-source community efforts/td>
+              <td>SW Developer; open-source community efforts</td>
             </tr>		
             <tr>
               <td><a href="https://github.com/aveiga">André Veiga</a></td>
@@ -2386,7 +2386,7 @@
             <tr>
               <td><a href="https://github.com/owenfarrell">Owen Farrell</a></td>
               <td>Individual</td>
-              <td>Development; open-source community efforts/td>
+              <td>Development; open-source community efforts</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
There were a few tags of <td> that were not closed properly. This started showing up as `td/>` on the HTML page which is rendered. Fixed this issue.