### PR TITLE
Adding my support

### DIFF
--- a/index.html
+++ b/index.html
@@ -2882,6 +2882,11 @@
               <td>Individual</td>
               <td>Platform Engineer; Software Engineer; open-source community efforts</td>
             </tr>
+	    <tr>
+              <td><a href="https://www.linkedin.com/in/jordan-lee-5056561b9/">Jordan Lee</a></td>
+              <td>Individual</td>
+              <td>DevOps Engineer; CI/CD; Azure Infrastructure; Testing; Documentation</td>
+            </tr>
           </tbody>
         </table>
         </div>


### PR DESCRIPTION
Terraform should be FOSS forever, it's only because of community input that it is successful. Vendors specifically maintain their own providers because hashicorp won't do it. 