### PR TITLE
Checkout repo instruction fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@
         </p>
 
         <ol>
-          <li>Check out the <a href="https://github.com/opentffoundation/manifesto">manifesto repo</a> (<a href="https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository">instructions</a>).</li>
+          <li>Check out the <a href="https://github.com/opentffoundation/manifesto">manifesto repo</a> (<a href="https://docs.github.com/en/get-started/quickstart/fork-a-repo">instructions</a>).</li>
           <li>Add a new row to the end of the table below with your details.</li>
           <li>Open a pull request with your changes (<a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request">instructions</a>).</li>
         </ol>


### PR DESCRIPTION
Original instructions recommend using repo cloning to checkout code when the fork is required.