### PR TITLE
reset body margin

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,11 +25,11 @@ body {
   line-height: 1.75;
   padding-top: 0rem;
   padding-bottom: 2rem;
-  margin-top: 0;
+  margin: 0;
 }
 
 div.container {
-  padding: 0 0.5em 0 0.5em;
+  padding: 0 1rem 0 1rem;
 }
 
 p {
@@ -384,7 +384,7 @@ span {
   background-color: #8a2be2;
   color: white;
   text-align: center;
-  padding: 10px 0;
+  padding: 0.75rem 0.5rem;
   font-size: 20px;
   text-decoration: none;
   transition: background-color 0.3s ease;


### PR DESCRIPTION
This PR resets the margin on `body` so that the purple banner looks better (especially on mobile).


| Before    | After |
| -------- | ------- |
|![2023-08-25 18 19 58](https://github.com/opentffoundation/manifesto/assets/7979992/02727c68-bf06-4fb4-8a96-821b5c91fd49)| ![2023-08-25 18 20 03](https://github.com/opentffoundation/manifesto/assets/7979992/44ddac67-7d64-411b-855d-9a76684b3356)|