### PR TITLE
Add Social Media Icon Hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -140,6 +140,8 @@ a:hover {
   font-family: Helvetica Neue, Helvetica, Arial, sans-serif
 }
 
+
+
 .resp-sharing-button__icon svg {
   width: 1em;
   height: 1em;
@@ -169,7 +171,9 @@ a:hover {
 }
 
 .resp-sharing-button--twitter:hover {
-  background-color: #2795e9
+  background-color: #2795e9;
+  transform: scale(1.1);
+
 }
 
 .resp-sharing-button--pinterest {
@@ -197,11 +201,13 @@ a:hover {
 }
 
 .resp-sharing-button--reddit {
-  background-color: #5f99cf
+  background-color: #5f99cf;
+  
 }
 
 .resp-sharing-button--reddit:hover {
-  background-color: #3a80c1
+  background-color: #3a80c1;
+  transform: scale(1.1);
 }
 
 .resp-sharing-button--google {
@@ -217,7 +223,8 @@ a:hover {
 }
 
 .resp-sharing-button--linkedin:hover {
-  background-color: #046293
+  background-color: #046293;
+  transform: scale(1.1);
 }
 
 .resp-sharing-button--email {
@@ -250,7 +257,8 @@ a:hover {
 
 .resp-sharing-button--hackernews:hover,
 .resp-sharing-button--hackernews:focus {
-  background-color: #FB6200
+  background-color: #FB6200;
+  transform: scale(1.1);
 }
 
 .resp-sharing-button--vk {


### PR DESCRIPTION
Fixes #764 

Added Social Media Icon `Hover` effect in `style.css`
Icons now scale up by `1.1` size when hovered over.