### PR TITLE
Change Github Star count Dynamically

### DIFF
--- a/announcement.html
+++ b/announcement.html
@@ -34,8 +34,32 @@
     <meta property="og:type" content="website">
     
     <script async defer src="https://buttons.github.io/buttons.js"></script>
+
+    <!-- Dynamically Update Github Stars Count -->
+    <script>
+      function updateStarCount() {
+          const repoUrl = "https://api.github.com/repos/opentffoundation/manifesto";
+
+          fetch(repoUrl)
+              .then(response => response.json())
+              .then(data => {
+                  const starCount = data.stargazers_count;
+                  let formattedStarCount;
+
+                  if (starCount >= 1000) {
+                      formattedStarCount = (starCount / 1000).toFixed(1) + "k";
+                  } else {
+                      formattedStarCount = starCount.toString();
+                  }
+
+                  const starElement = document.getElementById("star-count");
+                  starElement.textContent = formattedStarCount;
+              })
+              .catch(error => console.error("Error fetching star count:", error));
+      }
+  </script>
   </head>
-  <body>
+  <body onload="updateStarCount()">
     <div class="container mx-auto">
       <a href="/">
           <picture>
@@ -49,7 +73,7 @@
         <article class="blog-post">
           <p>Posted on: <time datetime="2023-08-25">August 25, 2023</time></p>
           <p class="subtle-margin"> 
-            Two weeks ago, HashiCorp announced they are changing the license to all their core products, including Terraform, to the Business Source License (BSL). In an attempt to keep Terraform open source, we published the <a href="https://opentf.org/">OpenTF manifesto</a>, and the community response was huge! Over 100 companies, 10 projects, and 400 individuals pledged their time and resources to keep Terraform open-source. The <a href="https://github.com/opentffoundation/manifesto">GitHub repository</a> for the manifesto already has over 4k stars, and the number is growing quickly!
+            Two weeks ago, HashiCorp announced they are changing the license to all their core products, including Terraform, to the Business Source License (BSL). In an attempt to keep Terraform open source, we published the <a href="https://opentf.org/">OpenTF manifesto</a>, and the community response was huge! Over 100 companies, 10 projects, and 400 individuals pledged their time and resources to keep Terraform open-source. The <a href="https://github.com/opentffoundation/manifesto">GitHub repository</a> for the manifesto already has over <span id="star-count">counting stars...</span> stars, and the number is growing quickly!
           </p>
           <p class="subtle-margin">
             The manifesto outlined the intent of the OpenTF initiative in two steps — the first was to appeal to HashiCorp to return Terraform to the community and revert the license change they were making for this project. The second, in case the license was not reverted, was to fork the Terraform project as OpenTF.


### PR DESCRIPTION
Addresses this issue #770 

I have added a basic script in the `head` tag of `announcement.html`  
Then I wrapped the star counting part in a `span` element.
 The body tag has an `onload` property which updated the `Github` star count each time.