### PR TITLE
Added "Stargazers over time" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ For further details and the full text of the manifesto, you can visit the [OpenT
 ## Contact
 
 If you have questions or feedback to share, you can reach the team behind this manifesto by emailing us at [pledge@opentf.org](mailto:pledge@opentf.org).
+
+
+## Stargazers over time
+
+[![Stargazers over time](https://starchart.cc/opentffoundation/manifesto.svg)](https://starchart.cc/opentffoundation/manifesto)
+


### PR DESCRIPTION
Saw it in [atlantis](https://github.com/runatlantis/atlantis) repo and thought it could be good idea to add it here too.

![image](https://github.com/opentffoundation/manifesto/assets/83922349/6aa21db0-72df-46ab-9e28-e3f45cf6a352)

### Note
I think that in order to see the [chart](https://starchart.cc/opentffoundation/manifesto) properly, the README snippet should be in the base repo, so currently it's not available in the preview.

