### PR TITLE
Fix overflow issue in co-signed counters

### DIFF
--- a/style.css
+++ b/style.css
@@ -334,6 +334,12 @@ a:hover {
   align-items: center;
 }
 
+@media (max-width: 480px) {
+  .share-social-media {
+    flex-direction: column;
+  }
+}
+
 .co-signed {
   width: 100%;
 }
@@ -360,6 +366,7 @@ figure blockquote {
 
 span {
   margin-right: 20px;
+  min-width: 0;
 }
 
 .count {


### PR DESCRIPTION
On my last PR #835 I made worse an overflow issue mainly on small screens, so here is my CSS fix for that.

Before the fix:
![imatge](https://github.com/opentffoundation/manifesto/assets/60898184/6fc2882d-03aa-4796-a550-31591650e966)
And after the fix:
![imatge](https://github.com/opentffoundation/manifesto/assets/60898184/6d5b6b48-8247-4018-91fb-b6031bca4eef)

You can see my fork with the fix implemented [here](https://alladeila.github.io/manifesto)