### PR TITLE
Add cirun labs pledge

### DIFF
--- a/index.html
+++ b/index.html
@@ -5279,6 +5279,11 @@
               <td>Company</td>
               <td>Platform Engineering, SRE, DevOps; Open-Source Community Efforts, Documentation, Evangelism</td>
             </tr>
+            <tr>
+              <td><a href="https://cirun.io">Cirun Labs</a></td>
+              <td>Company</td>
+              <td>Development; open-source community efforts</td>
+            </tr>
 	     <tr>
               <td><a href="https://github.com/pratikjain227">Pratik Jain</a></td>
               <td>Individual</td>


### PR DESCRIPTION
Adding pledge for cirun labs. We have moved from terraform to OpenTofu and are committed towards OpenTofu's manifesto.